### PR TITLE
Group_2:Complete

### DIFF
--- a/app/Http/Controllers/AirtableController.php
+++ b/app/Http/Controllers/AirtableController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ModelService;
+use App\Site;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Http\Request;
+use Tapp\Airtable\Api\AirtableApiClient;
+
+class AirtableController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function fetchModels($siteId)
+    {
+        $site = Site::findOrFail($siteId);
+        $modelService = new ModelService($site);
+
+        $models = $modelService->fetchAllModels();
+        return view('airtable.models', [
+            'siteName' => $site->name,
+            'models' => $models
+        ]);
+    }
+}

--- a/app/Http/Controllers/SitesController.php
+++ b/app/Http/Controllers/SitesController.php
@@ -7,6 +7,7 @@ use App\Site;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 use Maatwebsite\Excel\Facades\Excel;
@@ -112,5 +113,36 @@ class SitesController extends Controller
     public function export(): BinaryFileResponse
     {
         return Excel::download(new SitesExport($this->sites), 'site_export.csv', \Maatwebsite\Excel\Excel::CSV);
+    }
+
+    /**
+     * Display a detail of the resource.
+     * @param $id
+     * @return View
+     * @throws AuthorizationException
+     */
+    public function editSiteCredentials($id): View
+    {
+        $site = Site::findOrFail($id);
+        $this->authorize('view', $site);
+        return view('sites.EditCredentials', compact('site'));
+    }
+
+    /**
+     * Display a detail of the resource.
+     * @param Request $request
+     * @return RedirectResponse
+     */
+    public function storeSiteCredentials(Request $request): RedirectResponse
+    {
+        $site = Site::findOrFail($request->siteId);
+        $this->authorize('view', $site);
+
+        $site->base_id = $request->baseId;
+        $site->access_key = $request->accessKey;
+
+        $site->save();
+
+        return redirect()->route('sites.index');
     }
 }

--- a/app/Services/ModelService.php
+++ b/app/Services/ModelService.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services;
+
+use App\Site;
+use Tapp\Airtable\Api\AirtableApiClient;
+
+class ModelService
+{
+    protected $airtableApi;
+
+    public function __construct(Site $site)
+    {
+        $this->airtableApi = new AirtableApiClient($site->base_id, 'models', $site->access_key);
+    }
+
+    public function fetchAllModels(): array
+    {
+        try {
+            $modelArr = $this->airtableApi->getAllPages(20000)->toArray();
+            $pivotArr = $this->airtableApi->setTable('model_model')->getAllPages(20000)->toArray();
+        } catch (\Exception $e) {
+            return [];
+        }
+
+
+        return $this->buildTree($modelArr, $pivotArr);
+    }
+
+    private function setChild(array $modelArr, array $pivotArr, array $element): array
+    {
+        if (isset($element['fields']['children'])) {
+            foreach ($element['fields']['children'] as $key => $relationship_id) {
+                $child_id = '';
+                foreach ($pivotArr as $relationship) {
+                    if ($relationship['id'] === $relationship_id) {
+                        $child_id = $relationship['fields']['number'][0];
+                        break;
+                    }
+                }
+                foreach ($modelArr as $node) {
+                    if ($node['id'] === $child_id) {
+                        $node = $this->setChild($modelArr, $pivotArr, $node);
+                        $element['fields']['children'][$key] = $node;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return array_merge(['id' => $element['id']], $element['fields']);
+    }
+
+    private function buildTree(array $modelArr, array $pivotArr): array
+    {
+        $tree = [];
+        foreach ($modelArr as $node) {
+            if (!isset($node['fields']['parents'])) {
+                $tree[] = $this->setChild($modelArr, $pivotArr, $node);
+            }
+        }
+
+        return $tree;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "laravel/framework": "^6.2",
         "laravel/tinker": "^1.0",
         "league/csv": "9.0",
-        "maatwebsite/excel": "^3.1"
+        "maatwebsite/excel": "^3.1",
+        "tapp/laravel-airtable": "^0.21.0"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.2",

--- a/database/migrations/2023_02_20_065717_add_base_id_and_access_key_to_sites_table.php
+++ b/database/migrations/2023_02_20_065717_add_base_id_and_access_key_to_sites_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddBaseIdAndAccessKeyToSitesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('sites', function (Blueprint $table) {
+            $table->text('base_id')->nullable()->after('type');
+            $table->text('access_key')->nullable()->after('base_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('sites', function (Blueprint $table) {
+            $table->dropColumn('access_key');
+            $table->dropColumn('base_id');
+        });
+    }
+}

--- a/resources/views/airtable/modelChild.blade.php
+++ b/resources/views/airtable/modelChild.blade.php
@@ -1,0 +1,19 @@
+<ul>
+
+    @foreach($children as $child)
+
+        <li>
+
+            {{ $child['number'] }} ({{ $child['description'] }})
+
+            @if(isset($child['children']))
+
+                @include('airtable.modelChild',['children' => $child['children']])
+
+            @endif
+
+        </li>
+
+    @endforeach
+
+</ul>

--- a/resources/views/airtable/models.blade.php
+++ b/resources/views/airtable/models.blade.php
@@ -1,0 +1,40 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="col-md-6">
+
+            <h3>Models List of Site: {{$siteName}}</h3>
+
+            <ul id="tree1">
+                @if(!count($models))
+
+                    <h5>No models found or the access info is inappropriate!</h5>
+
+                @endif
+
+                @foreach($models as $model)
+
+                    <li>
+
+                        {{ $model['number'] }} ({{ $model['description'] }})
+
+                        @if(isset($model['children']))
+
+                            @include('airtable.modelChild',['children' => $model['children']])
+
+                        @endif
+
+                    </li>
+
+                @endforeach
+
+            </ul>
+
+        </div>
+    </div>
+
+
+{{--    <script src="{{ asset('js/treeview.js') }}"></script>--}}
+
+@endsection

--- a/resources/views/sites/EditCredentials.blade.php
+++ b/resources/views/sites/EditCredentials.blade.php
@@ -1,0 +1,54 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card">
+                    <div class="card-header"><h3>Change Credentials for Site: {{ $site->name }}</h3></div>
+
+                    <div class="card-body">
+                        @if (session('status'))
+                            <div class="alert alert-success" role="alert">
+                                {{ session('status') }}
+                            </div>
+                        @endif
+
+                        <form action="{{URL::route('sites.store-credentials')}}" method="post">
+                            {{ csrf_field() }}
+                            <input
+                                type="hidden"
+                                value={{$site->id}}
+                                id="siteId"
+                                name="siteId"
+                            >
+                            <div class="form-group">
+                                <label for="baseId">Site Base ID:</label>
+                                <input
+                                    type="text"
+                                    value="{{$site->base_id}}"
+                                    class="form-control"
+                                    id="baseId"
+                                    name="baseId"
+                                >
+                            </div>
+                            <div class="form-group">
+                                <label for="accessKey">Site Access Key:</label>
+                                <input
+                                    type="text"
+                                    value="{{$site->access_key}}"
+                                    class="form-control"
+                                    id="accessKey"
+                                    name="accessKey"
+                                >
+                            </div>
+                            <div class="form-group">
+                                <button type="submit" class="btn btn-primary">Submit</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/sites/index.blade.php
+++ b/resources/views/sites/index.blade.php
@@ -27,6 +27,7 @@
                                     <th>ID</th>
                                     <th>Name</th>
                                     <th>Type</th>
+                                    <th>Action</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -37,6 +38,9 @@
                                         <a href="/sites/{{ $site->id }}">{{ $site->name }}</a>
                                     </td>
                                     <td>Vessel</td>
+                                    <td>
+                                        <a class="btn btn-dark btn-xs" href="{{URL::route('sites.edit-credentials', ['id' => $site->id])}}">Add Credentials</a>
+                                    </td>
                                 </tr>
                                 @endforeach
                             </tbody>

--- a/resources/views/sites/show.blade.php
+++ b/resources/views/sites/show.blade.php
@@ -47,5 +47,7 @@
                 {{ $site->updated_at }}
             </div>
         </div>
-    </div></div>
+        <a class="btn btn-dark btn-xs" href="{{URL::route('airtable.models', ['siteId' => $site->id])}}">View Airtable Models</a>
+    </div>
+</div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,12 @@ Route::get('/home', 'HomeController@index')->name('home');
 
 Route::prefix('sites')->group(function () {
     Route::get('export', 'SitesController@export')->name('sites.export');
+    Route::get('edit-credentials/{id}', 'SitesController@editSiteCredentials')->name('sites.edit-credentials');
+    Route::post('store-credentials', 'SitesController@storeSiteCredentials')->name('sites.store-credentials');
+});
+
+Route::prefix('airtable')->group(function () {
+    Route::get('models/{siteId}', 'AirTableController@fetchModels')->name('airtable.models');
 });
 
 Route::resource('sites', 'SitesController');


### PR DESCRIPTION
Group 2:
4. Implement 3rd-party output for a Site

The Airtable base contains 4 tables for models, models relations, drawings and services. For this task you only need models and model_model tables.

Add fields to site entity to store access key and base ID
Implement a form to submit API credentials for a site.
Implement a Controller/View that fetches data from models table in Airtable and outputs models in a tree-like structure. References in children and parent are stored in model_model pivot.
UI is irrelevant. Feel free to use any 3rd-party library or output data with simple indentation.